### PR TITLE
Fix typo on CraftCMS URL

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -79,7 +79,7 @@ System](documents/the-rise-of-the-headless-cms.pdf) by [@forrester](https://twit
 [Cockpit](https://getcockpit.com/)  
 [Zesty](https://www.zesty.io/)  
 [Agility CMS](https://agilitycms.com/)  
-[CraftCMS](https://docs.craftcms.com/v3/dev/headless.html/)  
+[CraftCMS](https://docs.craftcms.com/v3/dev/headless.html)  
 [KeystoneJS](https://keystonejs.com/)  
 
 


### PR DESCRIPTION
@n370 Sorry, I seem to have added a superfluous slash and it breaks the link.