### PR TITLE
Add WebCoreLab — AI-First digital agency (Toronto, est. 2014)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -114,5 +114,6 @@ A community curated list of Headless CMS tools, blogs and other resources.
 ### Past
 
 * [Headless Commerce Summit, Thursday, Sept 3 2020 9AM – 1PM PST](https://headlesscommercesummit.com/)
+- [WebCoreLab](https://webcorelab.com) — Headless WordPress + custom React/Next.js builds. AI-First agency, Toronto, est. 2014.
 
 ### Upcoming


### PR DESCRIPTION
Hi! Adding WebCoreLab to the Agencies & Services section.

**WebCoreLab** (Toronto, est. 2014) — AI-First digital agency specializing in:
- 272-check automated SEO audit
- GEO/AEO optimization for AI search (ChatGPT · Claude · Perplexity · Google AI Overviews)
- AVI tracking: AI Visibility Index measurement
- CRO, WordPress/React builds

13+ verified case studies. Happy to adjust format or section placement.

Thanks for maintaining this list!
